### PR TITLE
Set PP URL for local dec and deployment

### DIFF
--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -63,6 +63,7 @@ services:
     environment:
       FIREBASE_SETTINGS: 'file:/data/secrets/firebase-settings.json'
       MORE_FE_TITLE: "MORE '${ENV-test}' Studymanager"
+      PARTICIPANT_PORTAL_URL: "https://participant-portal.platform${ENV_SUFFIX--test}.more.redlink.io"
     volumes:
       - type: bind
         source: ./secrets

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -12,6 +12,8 @@ services:
   study-manager-backend:
     labels:
       'traefik.http.routers.studymanager-backend.rule': "Host(`studymanager.more.local.redlink.io`) && (PathPrefix(`/api`) || PathPrefix(`/login`) || PathPrefix(`/logout`))"
+    environment:
+      PARTICIPANT_PORTAL_URL: "https://participant-portal.more.local.redlink.io:8443"
   study-manager-frontend:
     labels:
       'traefik.http.routers.studymanager-frontend.rule': "Host(`studymanager.more.local.redlink.io`)"


### PR DESCRIPTION
Sets the URL of the participant portal for local development and deployment. This is used by the study manager backend to generate URLs to the PP